### PR TITLE
fix: run ci for ink

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -71,7 +71,8 @@ jobs:
             42220,
             43114,
             59144,
-            534352,
+            57073,
+            534352
           ]
     name: Check all live payloads
     runs-on: ubuntu-latest


### PR DESCRIPTION
proposal 0 for Ink is https://github.com/bgd-labs/aave-proposals-v3/blob/9f17ca40bbb38a9c2522a892ea9b70a1749e24a5/src/20250814_Multi_GHOInkLaunch/AaveV3Ink_GHOInkLaunch_20250814.sol

omitted adding on e2e script since we may not want to run for whitelabel 